### PR TITLE
Allow client to configure the log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ config :libelection, :list_nodes, {module, function, args}
 config :libelection, :list_nodes, &SomeModule.some_function/1
 ```
 
+Configure the logger
+```elixir
+config :libelection, :logger, %{level: :debug} # Default
+```
+
 ## Election Strategies
 
 ### Rancher

--- a/lib/logger.ex
+++ b/lib/logger.ex
@@ -5,9 +5,23 @@ defmodule Election.Logger do
     quote do
       require Logger
 
-      def log(level, tag, fun) when is_function(fun), do: Logger.log(level, "#{tags(tag)} #{fun.()}")
-      def log(level, tag, message), do: Logger.log(level, "#{tags(tag)} #{message}")
+      def log(level, tag, fun) when is_function(fun), do: maybe_log(level, "#{tags(tag)} #{fun.()}")
+      def log(level, tag, message), do: maybe_log(level, "#{tags(tag)} #{message}")
       defp tags(tag), do: "[libelection][#{tag}]"
+
+      defp maybe_log(level, message) do
+        case Logger.compare_levels(log_level(), level) do
+          :gt -> nil
+          _ -> Logger.log(level, message)
+        end
+      end
+
+      defp log_level do
+        case Application.get_env(:libelection, :logger) do
+          %{level: level} -> level
+          _ -> :debug
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Locally we can get a lot of noise:

    17:23:10.571 [debug] [libelection][elector] No connected nodes. Leader unchanged :nonode@nohost

    17:23:11.572 [debug] [libelection][elector] No connected nodes. Leader unchanged :nonode@nohost

    17:23:12.573 [debug] [libelection][elector] No connected nodes. Leader unchanged :nonode@nohost

This allows the client to set the default log level of this application.